### PR TITLE
fix: change CI trigger to release events

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,11 +1,8 @@
 name: DDI Access Services CI
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
+on: 
+  release:
+    types: [released]
 
 jobs:
   check-version:


### PR DESCRIPTION
Update CI workflow to trigger on releases instead of pushes and pull requests.